### PR TITLE
Add ECC memory detection and display indicator

### DIFF
--- a/WPF/MainWindow.xaml
+++ b/WPF/MainWindow.xaml
@@ -174,17 +174,27 @@
                     </Grid.ColumnDefinitions>
 
                     <ComboBox x:Name="comboBoxPartNumber" IsReadOnly="True" Grid.Column="0" />
-                    <TextBlock
-                        Grid.Column="2"
-                        Text="{Binding MemoryType, FallbackValue=''}"
-                        Style="{DynamicResource ValueStyles}"
-                        Visibility="{Binding Settings.AdvancedMode, Mode=OneWay, Converter={StaticResource BoolToVis}}"
-                        TextAlignment="Right"
-                        HorizontalAlignment="Right"
-                        MinWidth="0"
-                        Margin="0"
-                        IsEnabled="False"
-                    />
+                    <StackPanel Grid.Column="2" Orientation="Horizontal" HorizontalAlignment="Right">
+                        <TextBlock
+                            Text="ECC"
+                            Style="{DynamicResource ValueStyles}"
+                            Visibility="{Binding ECC, Mode=OneWay, Converter={StaticResource BoolToVis}}"
+                            TextAlignment="Right"
+                            Margin="0,0,5,0"
+                            IsEnabled="False"
+                            ToolTip="Error-Correcting Code memory detected"
+                        />
+                        <TextBlock
+                            Text="{Binding MemoryType, FallbackValue=''}"
+                            Style="{DynamicResource ValueStyles}"
+                            Visibility="{Binding Settings.AdvancedMode, Mode=OneWay, Converter={StaticResource BoolToVis}}"
+                            TextAlignment="Right"
+                            HorizontalAlignment="Right"
+                            MinWidth="0"
+                            Margin="0"
+                            IsEnabled="False"
+                        />
+                    </StackPanel>
 
                     <!-- Button Grid.Column="1"
                             Width="20"

--- a/WPF/MainWindow.xaml.cs
+++ b/WPF/MainWindow.xaml.cs
@@ -177,6 +177,7 @@ namespace ZenTimings
                     cpu.GetMemoryConfig()?.SpdInfo?.Values.FirstOrDefault(d => d.IsValid)?.PmicData ?? null
                 );
 
+                mainViewModel.ECC = DetectECC();
                 DataContext = mainViewModel;
 
                 if (cpu != null && settings.AdvancedMode)
@@ -398,6 +399,26 @@ namespace ZenTimings
                     comboBoxPartNumber.SelectionChanged += ComboBoxPartNumber_SelectionChanged;
                 }
             }
+        }
+
+        private bool DetectECC()
+        {
+            try
+            {
+                using (ManagementObjectSearcher searcher = new ManagementObjectSearcher(
+                    "SELECT TotalWidth, DataWidth FROM Win32_PhysicalMemory"))
+                {
+                    foreach (ManagementObject obj in searcher.Get())
+                    {
+                        uint totalWidth = Convert.ToUInt32(obj["TotalWidth"] ?? 0);
+                        uint dataWidth = Convert.ToUInt32(obj["DataWidth"] ?? 0);
+                        if (totalWidth > dataWidth && totalWidth > 0)
+                            return true;
+                    }
+                }
+            }
+            catch { }
+            return false;
         }
 
         private void RefreshSensors()

--- a/WPF/ViewModels/MainViewModel.cs
+++ b/WPF/ViewModels/MainViewModel.cs
@@ -105,6 +105,9 @@ namespace ZenTimings.ViewModels
         }
         public MemType MemoryType { get; }
         public bool IsDimmTelemetryVisible => Settings.AdvancedMode && MemoryType == MemType.DDR5;
+
+        public bool ECC { get; set; }
+
         public PowerTable PowerTable { get; }
         public Cpu.CodeName CodeName { get; }
         public bool WMIPresent { get; }


### PR DESCRIPTION
Detects ECC RAM via WMI by comparing TotalWidth and DataWidth on each installed Win32_PhysicalMemory module. When TotalWidth exceeds DataWidth (e.g. 72 vs 64 bits) ECC is present, and a small 'ECC' label is shown in the bottom panel next to the memory type indicator.